### PR TITLE
Using a subpackage to run unit tests

### DIFF
--- a/.github/workflows/d.yml
+++ b/.github/workflows/d.yml
@@ -42,7 +42,7 @@ jobs:
           dub build --parallel -b release
           dub clean --all-packages -q
           # Run tests
-          dub test --parallel --coverage
+          dub test :silly-unittest --parallel --coverage
 
       - name: Upload Coverage to Codecov
         # Upload test coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.4.0
+
+* Moved unit-tests to a subpackage to avoid pollute other projects with
+    Pijamas unit-testing dependencies.
+
 # v0.3.5
 
 * Switching to GitHub CI

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ BTW, I'll be glad to accept help in writting the documentation.
 Run tests with:
 
 ```
-dub test
+dub test :silly-unittest 
 ```
 
 ## Why 'Pijamas'

--- a/ci.bat
+++ b/ci.bat
@@ -9,6 +9,6 @@ dub build -b release --compiler=%DC%
 dub clean --all-packages -q
 
 echo "Running tests"
-dub test --compiler=%DC% -v
+dub test :silly-unittest --compiler=%DC% -v
 
 

--- a/dub.json
+++ b/dub.json
@@ -7,18 +7,21 @@
     "Pedro Tacla Yamada",
     "Luis Panadero Guardeño"
   ],
-  "configurations": [
+  "targetType": "library",
+  "subPackages" : [
     {
-      "name": "pijamas",
-      "targetType": "library"
-    },
-    {
-      "name": "unittest",
+      "name": "silly-unittest",
       "targetType": "library",
       "importPaths": ["source", "tests"],
       "sourcePaths": ["source", "tests"],
       "dependencies": {
-        "silly": {"version": "~>1.1", "optional": true, "default": true}
+        "silly": {
+          "version": "~>1.1", "optional": true, "default": true
+        },
+        "pijamas":  {
+          "version": "*",
+          "path": "."
+        }
       }
     }
   ],


### PR DESCRIPTION
Implements #14 to avoid pollute projects using pijamas with Pijamas unit-test dependencies.